### PR TITLE
No guardar Selector CSS

### DIFF
--- a/atomo-headroom.js.yaml
+++ b/atomo-headroom.js.yaml
@@ -20,8 +20,8 @@ form:
       type: input.text
       description: Ingrese el selector CSS del elemento  que será fijado en la parte superior del navegador.Ejemplo:'#g-header'.
       label: Selector CSS
-      placeholder: '#g-header'
-      default: '#g-header'
+      placeholder: '#g-navigation'
+
 
     offset:
       type: input.text
@@ -110,6 +110,8 @@ form:
         hinge: hinge
         rollIn: rollIn
         rollOut: rollOut
+        
+        
     animationbajascroll:
       type: select.select
       label: Efecto de salida
@@ -191,6 +193,8 @@ form:
         hinge: hinge
         rollIn: rollIn
         rollOut: rollOut
+        
+        
     mobile:
       type: select.select
       label: Movil

--- a/atomo-headroom.js.yaml
+++ b/atomo-headroom.js.yaml
@@ -18,10 +18,10 @@ form:
 
     cssselector:
       type: input.text
-      description: Ingrese el selector CSS del elemento  que será fijado en la parte superior del navegador.Ejemplo:'#g-header'.
+      description: Ingrese el selector CSS del elemento  que será fijado en la parte superior del navegador.Ejemplo:'#g-navigation'.
       label: Selector CSS
       placeholder: '#g-navigation'
-
+      default: '#g-navigation'
 
     offset:
       type: input.text


### PR DESCRIPTION
He echo unos cambios para que se guarde la posicion donde se usara el efecto, al guardar funcciona de maravilla,pero al abrir para configurar de nuevo o cambiar tranziciones/animaciones, vuelve a recordar lo mismo del principio.


He e pensado que la mayoria usaran #g-navigation .

Muchas Gracias por el aporte de hacer esta particula y por todas tus particulas y compartirlas.
Un saludo.


